### PR TITLE
docs: extend installtion information for project

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,12 @@ I do know there is a addon like this already in development, check it out at the
 
 To install the addon download the source files and put the "addons" folder on a root level to your project. After that enable the plugin via the Godot plugin menu.
 
-Checkout this part of the [Godot documentation][installing-and-enable-plugin]
+Checkout this part of the [Godot documentation][installing-and-enable-plugin].
+
+> :warning: If you install the plugin and it is not active it is possible that godot will throw errors that the identifier "Console" cannot be found. To fix this issues you just need to activate the plugin, this error is a result of an dependency to that global instance, which is not present after install throwing an error on Godot automatic code check.
+
+![Installation error](https://i.imgur.com/5HuV62g.png)
+*Error listed because Console is not loaded just yet, this is normal*
 
 ## Quickstart
 


### PR DESCRIPTION
Add description for installation issue telling the user that the
"Console" could not be found.
