### PR TITLE
feat: add autocomplete for multiple terms

### DIFF
--- a/addons/gameconsole/console/console.gd
+++ b/addons/gameconsole/console/console.gd
@@ -27,7 +27,7 @@ var _first_time_open: bool = true
 var _console_information := {
 	"name": "Game Console",
 	"authors": "Xanatos",
-	"version": "0.3.2"
+	"version": "0.4.0"
 }
 
 func _ready():

--- a/addons/gameconsole/console/console/command_enter.gd
+++ b/addons/gameconsole/console/console/command_enter.gd
@@ -1,15 +1,22 @@
 class_name ConsoleInput extends LineEdit
 
+signal reset_autocomplete()
+
 @export var non_existing_function_color: Color = Color(0.85, 0, 0)
 @export var existing_function_color: Color = Color(0, 0.65, 0)
+@export var autocomplete_available: Color = Color(1, 0.65, 0)
+@export var enable_autocomplete_color: bool = true
 
 var _current_history: Array[String] = []
 
 var _index = -1
 var _save_file: String = "user://c_history"
+var _autocomplete_found: bool = false
+var _autocomplete_color_active: bool = false
 
 func _ready():
 	text_submitted.connect(_submitted)
+	_autocomplete_color_active = enable_autocomplete_color
 	if !FileAccess.file_exists(_save_file):
 		return
 	var data = FileAccess.get_file_as_string(_save_file)
@@ -24,6 +31,7 @@ func _submitted(text: String):
 	_current_history.append(text)
 	if _current_history.size() > 100:
 		_current_history.pop_front()
+	reset_autocomplete.emit()
 
 func _exit_tree():
 	if _current_history.size() == 0:
@@ -62,15 +70,32 @@ func _update_selection_text():
 		caret_column = text.length()
 		get_tree().get_root().set_input_as_handled()
 
+func autocompletion_found(data: Array[StrippedCommand]):
+	if !enable_autocomplete_color or !_autocomplete_color_active:
+		return
+	if !data.is_empty():
+		_change_color(autocomplete_available)
+		_autocomplete_found = true
+		return
+
 func autocomplete_accepted(autocomplete_text: String):
 	text = autocomplete_text
 	await get_tree().physics_frame
 	grab_focus()
 	caret_column = text.length()
+	_autocomplete_color_active = false
 	text_changed.emit(text)
+	await get_tree().physics_frame
+	_autocomplete_color_active = true
 
 func is_command_valid(confirmed: bool):
+	if _autocomplete_found:
+		_autocomplete_found = false
+		return
 	if confirmed:
-		add_theme_color_override("font_color", existing_function_color)
+		_change_color(existing_function_color)
 	else:
-		add_theme_color_override("font_color", non_existing_function_color)
+		_change_color(non_existing_function_color)
+
+func _change_color(color: Color):
+	add_theme_color_override("font_color", color)

--- a/addons/gameconsole/console/console/command_send_button.gd
+++ b/addons/gameconsole/console/console/command_send_button.gd
@@ -1,6 +1,7 @@
 class_name ConsoleSendButton extends Button
 
 signal request_command(text: String)
+signal reset_autocomplete()
 
 @export var command_input: LineEdit
 
@@ -11,3 +12,5 @@ func _ready():
 
 func _pressed():
 	request_command.emit(command_input.text)
+	reset_autocomplete.emit()
+	command_input.grab_focus()

--- a/addons/gameconsole/console/console/console_template.gd
+++ b/addons/gameconsole/console/console/console_template.gd
@@ -10,7 +10,7 @@ signal set_input(command: String)
 signal clear_output()
 signal clear_input()
 
-signal autocomplete_found(autocompletion: StrippedCommand)
+signal autocomplete_found(autocompletion: Array[StrippedCommand])
 
 @export_group("GameConsole Setup")
 @export var console_content_output: ConsoleOutput
@@ -25,10 +25,6 @@ func _ready():
 		
 	if console_input == null:
 		printerr("GameConsole template is missing input box")
-		queue_free()
-		
-	if console_send_button == null:
-		printerr("GameConsole template is missing send button")
 		queue_free()
 
 	Console._register_custom_builtin_command("clear", clear_command,  [], "Command to clear the console window")
@@ -57,7 +53,7 @@ func autocomplete_requested(typed: String):
 
 	var matches = autocomplete_service.search_autocomplete(typed)
 	if matches.size() > 0:
-		autocomplete_found.emit(matches[0])
+		autocomplete_found.emit(matches)
 
 func close_requested():
 	store_content.emit(console_content_output.get_stored_text())

--- a/addons/gameconsole/console/console/default_console_template.tscn
+++ b/addons/gameconsole/console/console/default_console_template.tscn
@@ -1,23 +1,21 @@
-[gd_scene load_steps=8 format=3 uid="uid://c71do5a646sh0"]
+[gd_scene load_steps=7 format=3 uid="uid://c71do5a646sh0"]
 
 [ext_resource type="Script" path="res://addons/gameconsole/console/console/console_template.gd" id="1_wfkix"]
 [ext_resource type="Script" path="res://addons/gameconsole/console/console/command_enter.gd" id="2_1bnin"]
 [ext_resource type="Script" path="res://addons/gameconsole/console/autocompletion/autocomplete_service.gd" id="2_5ui7n"]
-[ext_resource type="Script" path="res://addons/gameconsole/console/console/command_send_button.gd" id="2_p027c"]
 [ext_resource type="Script" path="res://addons/gameconsole/console/console/console_output.gd" id="3_m4yog"]
 [ext_resource type="Script" path="res://addons/gameconsole/console/console/autocomplete_label.gd" id="4_jxlgx"]
 
 [sub_resource type="Resource" id="Resource_vkyqv"]
 script = ExtResource("2_5ui7n")
 
-[node name="CommandLineTemplate" type="CanvasLayer" node_paths=PackedStringArray("console_content_output", "console_input", "console_send_button")]
+[node name="CommandLineTemplate" type="CanvasLayer" node_paths=PackedStringArray("console_content_output", "console_input")]
 process_mode = 3
 layer = 20
 script = ExtResource("1_wfkix")
-autocomplete_service = SubResource("Resource_vkyqv")
 console_content_output = NodePath("PanelContainer/MarginContainer/VBoxContainer/ConsoleOutput")
 console_input = NodePath("PanelContainer/MarginContainer/VBoxContainer/VBoxContainer/HBoxContainer/ConsoleInput")
-console_send_button = NodePath("PanelContainer/MarginContainer/VBoxContainer/VBoxContainer/HBoxContainer/ConsoleSendButton")
+autocomplete_service = SubResource("Resource_vkyqv")
 
 [node name="PanelContainer" type="PanelContainer" parent="."]
 anchors_preset = 10
@@ -63,20 +61,13 @@ theme_override_font_sizes/font_size = 14
 placeholder_text = "Enter Command use up and down to navigate history"
 script = ExtResource("2_1bnin")
 
-[node name="ConsoleSendButton" type="Button" parent="PanelContainer/MarginContainer/VBoxContainer/VBoxContainer/HBoxContainer" node_paths=PackedStringArray("command_input")]
-layout_mode = 2
-size_flags_vertical = 0
-theme_override_font_sizes/font_size = 14
-text = "Send"
-script = ExtResource("2_p027c")
-command_input = NodePath("../ConsoleInput")
-
 [node name="ConsoleAutocomplete" type="Label" parent="PanelContainer/MarginContainer/VBoxContainer/VBoxContainer"]
 visible = false
 layout_mode = 2
 theme_override_font_sizes/font_size = 14
 script = ExtResource("4_jxlgx")
 
+[connection signal="autocomplete_found" from="." to="PanelContainer/MarginContainer/VBoxContainer/VBoxContainer/HBoxContainer/ConsoleInput" method="autocompletion_found"]
 [connection signal="autocomplete_found" from="." to="PanelContainer/MarginContainer/VBoxContainer/VBoxContainer/ConsoleAutocomplete" method="autocompletion_found"]
 [connection signal="clear_input" from="." to="PanelContainer/MarginContainer/VBoxContainer/VBoxContainer/HBoxContainer/ConsoleInput" method="clear"]
 [connection signal="clear_output" from="." to="PanelContainer/MarginContainer/VBoxContainer/ConsoleOutput" method="clear_stored_text"]
@@ -84,6 +75,7 @@ script = ExtResource("4_jxlgx")
 [connection signal="output_append" from="." to="PanelContainer/MarginContainer/VBoxContainer/ConsoleOutput" method="append_bbcode_text"]
 [connection signal="set_input" from="." to="PanelContainer/MarginContainer/VBoxContainer/VBoxContainer/HBoxContainer/ConsoleInput" method="autocomplete_accepted"]
 [connection signal="meta_clicked" from="PanelContainer/MarginContainer/VBoxContainer/ConsoleOutput" to="." method="url_requested"]
+[connection signal="reset_autocomplete" from="PanelContainer/MarginContainer/VBoxContainer/VBoxContainer/HBoxContainer/ConsoleInput" to="PanelContainer/MarginContainer/VBoxContainer/VBoxContainer/ConsoleAutocomplete" method="force_reset"]
 [connection signal="text_changed" from="PanelContainer/MarginContainer/VBoxContainer/VBoxContainer/HBoxContainer/ConsoleInput" to="." method="autocomplete_requested"]
 [connection signal="text_changed" from="PanelContainer/MarginContainer/VBoxContainer/VBoxContainer/HBoxContainer/ConsoleInput" to="." method="check_if_is_valid_command"]
 [connection signal="text_changed" from="PanelContainer/MarginContainer/VBoxContainer/VBoxContainer/HBoxContainer/ConsoleInput" to="PanelContainer/MarginContainer/VBoxContainer/VBoxContainer/ConsoleAutocomplete" method="text_updated"]

--- a/addons/gameconsole/plugin.cfg
+++ b/addons/gameconsole/plugin.cfg
@@ -3,5 +3,5 @@
 name="Game Console"
 description="Addon to add a console to the game, allowing you to register and run commands."
 author="Xanatos"
-version="0.3.2"
+version="0.4.0"
 script="gameconsole.gd"

--- a/example/custom_console_template.tscn
+++ b/example/custom_console_template.tscn
@@ -15,10 +15,10 @@ bg_color = Color(0.136826, 0.136826, 0.136826, 1)
 
 [node name="CustomConsoleTemplate" type="CanvasLayer" node_paths=PackedStringArray("console_content_output", "console_input", "console_send_button")]
 script = ExtResource("1_rkm11")
-autocomplete_service = SubResource("Resource_lhmvy")
 console_content_output = NodePath("PanelContainer/MarginContainer/VBoxContainer/ConsoleOutput")
 console_input = NodePath("PanelContainer/MarginContainer/VBoxContainer/HBoxContainer/VBoxContainer/ConsoleInput")
 console_send_button = NodePath("PanelContainer/MarginContainer/VBoxContainer/HBoxContainer/ConsoleSendButton")
+autocomplete_service = SubResource("Resource_lhmvy")
 
 [node name="PanelContainer" type="PanelContainer" parent="."]
 anchors_preset = 9
@@ -62,6 +62,7 @@ script = ExtResource("4_7fr1q")
 command_input = NodePath("../VBoxContainer/ConsoleInput")
 
 [connection signal="autocomplete_found" from="." to="PanelContainer/MarginContainer/VBoxContainer/HBoxContainer/VBoxContainer/ConsoleAutocomplete" method="autocompletion_found"]
+[connection signal="autocomplete_found" from="." to="PanelContainer/MarginContainer/VBoxContainer/HBoxContainer/VBoxContainer/ConsoleInput" method="autocompletion_found"]
 [connection signal="clear_input" from="." to="PanelContainer/MarginContainer/VBoxContainer/HBoxContainer/VBoxContainer/ConsoleInput" method="clear"]
 [connection signal="clear_output" from="." to="PanelContainer/MarginContainer/VBoxContainer/ConsoleOutput" method="clear_stored_text"]
 [connection signal="is_command_valid" from="." to="PanelContainer/MarginContainer/VBoxContainer/HBoxContainer/VBoxContainer/ConsoleInput" method="is_command_valid"]
@@ -69,8 +70,10 @@ command_input = NodePath("../VBoxContainer/ConsoleInput")
 [connection signal="set_input" from="." to="PanelContainer/MarginContainer/VBoxContainer/HBoxContainer/VBoxContainer/ConsoleInput" method="autocomplete_accepted"]
 [connection signal="meta_clicked" from="PanelContainer/MarginContainer/VBoxContainer/ConsoleOutput" to="." method="url_requested"]
 [connection signal="autocomplete_accepted" from="PanelContainer/MarginContainer/VBoxContainer/HBoxContainer/VBoxContainer/ConsoleAutocomplete" to="PanelContainer/MarginContainer/VBoxContainer/HBoxContainer/VBoxContainer/ConsoleInput" method="autocomplete_accepted"]
+[connection signal="reset_autocomplete" from="PanelContainer/MarginContainer/VBoxContainer/HBoxContainer/VBoxContainer/ConsoleInput" to="PanelContainer/MarginContainer/VBoxContainer/HBoxContainer/VBoxContainer/ConsoleAutocomplete" method="force_reset"]
 [connection signal="text_changed" from="PanelContainer/MarginContainer/VBoxContainer/HBoxContainer/VBoxContainer/ConsoleInput" to="." method="autocomplete_requested"]
 [connection signal="text_changed" from="PanelContainer/MarginContainer/VBoxContainer/HBoxContainer/VBoxContainer/ConsoleInput" to="." method="check_if_is_valid_command"]
 [connection signal="text_changed" from="PanelContainer/MarginContainer/VBoxContainer/HBoxContainer/VBoxContainer/ConsoleInput" to="PanelContainer/MarginContainer/VBoxContainer/HBoxContainer/VBoxContainer/ConsoleAutocomplete" method="text_updated"]
 [connection signal="text_submitted" from="PanelContainer/MarginContainer/VBoxContainer/HBoxContainer/VBoxContainer/ConsoleInput" to="." method="request_command"]
 [connection signal="request_command" from="PanelContainer/MarginContainer/VBoxContainer/HBoxContainer/ConsoleSendButton" to="." method="request_command"]
+[connection signal="reset_autocomplete" from="PanelContainer/MarginContainer/VBoxContainer/HBoxContainer/ConsoleSendButton" to="PanelContainer/MarginContainer/VBoxContainer/HBoxContainer/VBoxContainer/ConsoleAutocomplete" method="force_reset"]


### PR DESCRIPTION
Remove the send button from default console.

This feature will add the possibility to click tab multiple times to get other autocomplete results. It will also write the console text in orange if there is any autocomplete available, making it easier to use.

Fix #26