### PR TITLE
feat: add data types to command arguments

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,6 +34,30 @@ func _reload() -> String:
 	get_tree().reload_current_scene()
 	return "reloaded scene"
 ```
+> This will add an command where the arguments are provided as Strings, your method accepting those arguments will get strings as well
+> you will need to convert to the correct data type all by yourself.
+
+### Register a strong argument command
+
+```gdscript
+Console.register_custom_strong_command("spawn_entity",
+                                       _spawn_entity,
+                                       [CommandArgument.new(CommandArgument.Type.INT, "X Position", "The x position on screen for the entity"),
+                                        CommandArgument.new(CommandArgument.Type.INT, "y Position", "The y position on screen for the entity"),
+                                        CommandArgument.new(CommandArgument.Type.FLOAT, "time to life", "The time the entity should life in seconds")
+                                       ],
+                                       "Spawn an example entity at a global position",
+                                       "",
+                                       ["spawn_entity 200 300 4"]
+                                      )
+
+func _spawn_entity(pos_x: int, pos_y: int, ttl: float) -> String:
+    pass
+
+```
+> This will add a new argument but the argument types are defined, this will parse the input data automatically making it easier to use in your method. If a wrong type was provided to any
+> of the arguments an error will be thrown preventing the method execution.
+
 
 ### Unregister a command
 

--- a/addons/gameconsole/builtin/command_argument_count_not_matching.gd
+++ b/addons/gameconsole/builtin/command_argument_count_not_matching.gd
@@ -1,7 +1,11 @@
 extends CommandTemplate
 
 func create_command() -> Command:
-    var command = Command.new("argument not matching", _argument_count_not_matching, ["command_name"], "The provided arguments do not match")
+    var command = Command.new("argument not matching",
+							  _argument_count_not_matching,
+							  [CommandArgument.new(CommandArgument.Type.STRING, "Command Name", "")],
+							  "The provided arguments do not match"
+							  )
     command.is_hidden = true
     return command
 

--- a/addons/gameconsole/builtin/command_argument_not_valid.gd
+++ b/addons/gameconsole/builtin/command_argument_not_valid.gd
@@ -1,0 +1,18 @@
+extends CommandTemplate
+
+func create_command() -> Command:
+	var command = Command.new("argument_not_valid",
+							  _argument_is_not_valid,
+							  [CommandArgument.new(CommandArgument.Type.STRING, "Command Name", ""),
+							   CommandArgument.new(CommandArgument.Type.STRING, "Argument Name", ""),
+							   CommandArgument.new(CommandArgument.Type.STRING, "Expected Type", ""),
+							   CommandArgument.new(CommandArgument.Type.STRING, "Provided Data", "")
+							  ],
+							  "The type of the given argument is not correct"
+							  )
+	command.is_hidden = true
+	return command
+
+func _argument_is_not_valid(command_name: String, argument_name: String, expected_type: String, provided_data: String) -> String:
+	argument_name = argument_name.replace("_", " ")
+	return "[color=red]Command \"%s\" does require (%s) type for argument \"%s\" but provided value was \"%s\"[/color]" % [command_name, expected_type, argument_name, provided_data]

--- a/addons/gameconsole/builtin/command_man.gd
+++ b/addons/gameconsole/builtin/command_man.gd
@@ -1,10 +1,15 @@
 extends CommandTemplate
 
 func create_command() -> Command:
-    var command = Command.new("man", manual, ["Name of the command"], "Command to get a manual for an command", "", ["man list_commands"])
+    var command = Command.new("man",
+							  _manual,
+							  [CommandArgument.new(CommandArgument.Type.STRING, "Name of the command", "")],
+							  "Command to get a manual for an command",
+							  "",
+							  ["man list_commands"])
     return command
 
-func manual(command_name: String) -> String:
+func _manual(command_name: String) -> String:
     var command = Console.get_specific_command(command_name)
     if command == null or command.is_hidden:
         return "[color=red]No command with name %s was found[/color]" % command_name

--- a/addons/gameconsole/builtin/command_not_found.gd
+++ b/addons/gameconsole/builtin/command_not_found.gd
@@ -1,7 +1,11 @@
 extends CommandTemplate
 
 func create_command() -> Command:
-    var command = Command.new("not found", _not_found, ["Command name"], "Command was not found")
+    var command = Command.new("not found",
+							  _not_found,
+							  [CommandArgument.new(CommandArgument.Type.STRING, "Command Name", "")],
+							  "Command was not found"
+							 )
     command.is_hidden = true
     return command
 

--- a/addons/gameconsole/console/command/command_argument.gd
+++ b/addons/gameconsole/console/command/command_argument.gd
@@ -1,0 +1,75 @@
+class_name CommandArgument extends Resource
+
+enum Type
+{
+	UNKNOWN,
+	STRING,
+	INT,
+	FLOAT,
+	BOOL,
+}
+
+var _argument_type: Type
+var _argument_name: String
+var _argument_description: String = ""
+
+func _init(type: Type, name: String, description: String):
+	_argument_type = type
+	_argument_name = name
+	_argument_description = description
+	
+func get_type() -> Type:
+	return _argument_type
+
+func get_display_name() -> String:
+	var prefix: String = "(%s)"
+	match _argument_type:
+		Type.UNKNOWN:
+			prefix = ""
+		Type.STRING:
+			prefix = prefix % "String"
+		Type.INT:
+			prefix = prefix % "Int"
+		Type.FLOAT:
+			prefix = prefix % "Float"
+		Type.BOOL:
+			prefix = prefix % "Bool 0/1"
+	return "%s %s" % [prefix, _argument_name]
+
+func get_description() -> String:
+	return _argument_description
+
+func is_valid_for(data: String) -> bool:
+	match _argument_type:
+		Type.UNKNOWN:
+			return true
+		Type.STRING:
+			return true
+		Type.INT:
+			return data.is_valid_int()
+		Type.FLOAT:
+			return data.is_valid_float()
+		Type.BOOL:
+			if not data.is_valid_int():
+				return false
+			var converted_data = int(data)
+			return converted_data == 0 or converted_data == 1
+		_:
+			return false
+
+func convert_data(data: String) -> Variant:
+	if not is_valid_for(data):
+		return null
+	match _argument_type:
+		Type.UNKNOWN:
+			return data
+		Type.STRING:
+			return data
+		Type.INT:
+			return int(data)
+		Type.FLOAT:
+			return float(data)
+		Type.BOOL:
+			return int(data) == 1
+		_:
+			return null

--- a/addons/gameconsole/console/command/stripped_command.gd
+++ b/addons/gameconsole/console/command/stripped_command.gd
@@ -1,4 +1,4 @@
 class_name StrippedCommand extends Resource
 
 var command: String
-var arguments: PackedStringArray
+var arguments: Array[CommandArgument]

--- a/addons/gameconsole/console/console.gd
+++ b/addons/gameconsole/console/console.gd
@@ -150,15 +150,29 @@ func _register_builtin_command(command: Command):
 	command.built_in = true
 	_console_commands[command.get_command_name()] = command
 
-func register_custom_command(command: String,
-									  function: Callable,
-									  in_arguments : PackedStringArray = [],
-									  short_description: String = "",
-									  description: String = "",
-									  example: PackedStringArray = []):
+## Register a custom command with strong typed parameters
+func register_custom_strong_command(command: String,
+							 function: Callable,
+							 in_arguments: Array[CommandArgument],
+							 short_description: String = "",
+							 description: String = "",
+							 example: PackedStringArray = []):
 	var real_command = Command.new(command, function, in_arguments, short_description, description, example)
 	register_command(real_command)
 
+## Register a custom command without using the new parameter types
+func register_custom_command(command: String,
+							 function: Callable,
+							 in_arguments : PackedStringArray = [],
+							 short_description: String = "",
+							 description: String = "",
+							 example: PackedStringArray = []):
+	var converted_arguments: Array[CommandArgument] = []
+	for argument in in_arguments:
+		converted_arguments.append(CommandArgument.new(CommandArgument.Type.UNKNOWN, argument, ""))
+	register_custom_strong_command(command, function, converted_arguments, short_description, description, example)
+
+## Register a new command you already created the object instance for
 func register_command(command: Command):
 	var name = command.get_command_name()
 	command.built_in = false
@@ -180,8 +194,6 @@ func search_and_execute_command(command_text: String):
 	if command_to_run == null:
 		search_and_execute_command("not_found %s" % executer.command)
 		return
-	if executer.arguments.size() != command_to_run.arguments.size():
-		search_and_execute_command("argument_not_matching %s" % executer.command)
 	var result = command_to_run.execute(executer.arguments)
 	if result != "":
 		console_output.emit(result + "\n")

--- a/addons/gameconsole/console/console/autocomplete_label.gd
+++ b/addons/gameconsole/console/console/autocomplete_label.gd
@@ -43,7 +43,7 @@ func _display_autocomplete(data: StrippedCommand):
 		var color: Color = Console.console_settings.autocomplete_argument_color_odd
 		if argument_counter % 2 == 0:
 			color = Console.console_settings.autocomplete_argument_color_even
-		arguments += "[color=%s]%s[/color] " % [color.to_html(), argument]
+		arguments += "[color=%s]%s[/color] " % [color.to_html(), argument.get_display_name()]
 		argument_counter += 1
 	arguments = arguments.trim_suffix(" ")
 

--- a/example/console_example.gd
+++ b/example/console_example.gd
@@ -39,16 +39,19 @@ func _register_commands():
 
 	var count_down_command = Command.new("count_down",
 										 _count_down,
-										["(int) amount to count down"],
+										[CommandArgument.new(CommandArgument.Type.INT, "amount", "The amount to count down from the current counter")],
 										"Decrease the internal counter",
 										"Command will decrease a local counter",
 										["count_down 1", "count_down 5"])
 
 	Console.register_command(count_down_command)
 	Console.register_custom_command("reload", _reload, [], "Reload current scene")
-	Console.register_custom_command("spawn_entity",
+	Console.register_custom_strong_command("spawn_entity",
 	 								_spawn_entity,
-									["(int) X Position", "(int) Y Position", "(float) time to life" ],
+									[CommandArgument.new(CommandArgument.Type.INT, "X Position", "The x position on screen for the entity"),
+									 CommandArgument.new(CommandArgument.Type.INT, "y Position", "The y position on screen for the entity"),
+									 CommandArgument.new(CommandArgument.Type.FLOAT, "time to life", "The time the entity should life in seconds")
+									],
 									"Spawn an example entity at a global position",
 									"",
 									["spawn_entity 200 300 4"]
@@ -61,36 +64,24 @@ func _register_commands():
 		Console.register_custom_command("custom_console", _open_custom_console, [], "Open your custom console", "", [])
 		Console.register_custom_command("default_console", _open_default_console, [], "Open the default console", "", [])
 	
-func _spawn_entity(pos_x: String, pos_y: String, ttl: String) -> String:
-	if !pos_x.is_valid_int():
-		return "first argument was not a valid int"
-	if !pos_y.is_valid_int():
-		return "second argument was not a valid int"
-	if !pos_y.is_valid_float():
-		return "third argument was not a valid int"
-
-
-	var real_x = int(pos_x)
-	var real_y = int(pos_y)
-	var real_ttl = float(ttl)
-
-	_trigger_spawn_entity(real_x, real_y, real_ttl)
+func _spawn_entity(pos_x: int, pos_y: int, ttl: float) -> String:
+	_trigger_spawn_entity(pos_x, pos_y, ttl)
 
 	var custom_interaction = Interaction.new()
 	var custom_edit = Interaction.new()
 
 	# The second parameter would be some identifier to find entity to spawn
 	custom_interaction.from_raw("spawn_entity", "entity_example", {
-		"x": real_x,
-		"y": real_y,
-		"ttl": real_ttl
+		"x": pos_x,
+		"y": pos_y,
+		"ttl": ttl
 	})
 
 	custom_edit.from_raw("enter", "spawn_entity %s %s %s" % [pos_x, pos_y, ttl])
 
-	return "Spawn entity at (%s/%s) with a ttl of %s [url=%s]retrigger[/url] or [url=%s]edit[/url]" % [real_x,
-																									   real_y,
-																									   real_ttl,
+	return "Spawn entity at (%s/%s) with a ttl of %s [url=%s]retrigger[/url] or [url=%s]edit[/url]" % [pos_x,
+																									   pos_y,
+																									   ttl,
 																									   custom_interaction.get_as_string(),
 																									   custom_edit.get_as_string()
 																									  ]
@@ -112,12 +103,9 @@ func _count_up(amount: String) -> String:
 	counter += parsed_amount
 	return "Increased counter from %s to %s" % [old_counter, counter]
 
-func _count_down(amount: String) -> String:
-	if not amount.is_valid_int():
-		return "[color=red]Argument was not a valid int[/color]"
-	var parsed_amount = int(amount)
+func _count_down(amount: int) -> String:
 	var old_counter = counter
-	counter -= parsed_amount
+	counter -= amount
 	return "Decreased counter from %s to %s" % [old_counter, counter]
 
 func _open_custom_console():


### PR DESCRIPTION
This change will allow commands to define a data type per argument, this will make the usage more user friendly if commands are getting registered. You can now choose the data types and the console will validate the input throwing an error if something went wrong.

Add new method to add commands with strong typed arguments. Change example to use new method for strong typed arguments.

Fix #43

BREAKING_CHANGE: This will add some breaking changes, if you create a command instance you cannot use the packedstring array anymore. Instead create a new "CommandArgument" providing the type as first parameter, the name as the second and if needed a description of the parameter as last.