### PR TITLE
feat: allow strings with spaces

### DIFF
--- a/addons/gameconsole/console/command/command_definition.gd
+++ b/addons/gameconsole/console/command/command_definition.gd
@@ -7,7 +7,7 @@ func _init(text: String) -> void:
 	if text == "":
 		command = "no_command_provided"
 		return
-	var tokens: PackedStringArray = text.split(" ")
+	var tokens: PackedStringArray = _tokenize_command(text)
 	if tokens.size() == 1:
 		command = tokens[0]
 		return
@@ -16,5 +16,31 @@ func _init(text: String) -> void:
 	for token: String in loaded_tokens:
 		if token.is_empty():
 			continue
+
 		arguments.append(token)
 	
+func _tokenize_command(text: String) -> PackedStringArray:
+	var tokens: PackedStringArray = []
+	var current: String = ""
+	var in_quotes: bool = false
+	
+	for char in text:
+		if char == "\"":
+			in_quotes = !in_quotes
+			if not current == "" and not in_quotes:
+				tokens.append(current)
+				current = ""
+			continue
+		
+		if char == " " and not in_quotes:
+			if not current == "":
+				tokens.append(current)
+				current = ""
+			continue
+		
+		current += char
+
+	if not current == "":
+		tokens.append_array(current.split(" "))
+
+	return tokens


### PR DESCRIPTION
Commit will write a custom tokenizer which will ensure that quoted
strings are kept together. This allows for longer command arguments.

fix #48
